### PR TITLE
Add a download link for direct download

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple workflow for searching CocoaPods.
 ![screenshot](http://f.cl.ly/items/0y383Y1C3O2B2336040M/Screen%20Shot%202013-04-11%20at%2012.34.55%20PM.png)
 
 **How to use it**
+
+- [Download](https://github.com/alladinian/Alfred-CocoaPods-Search/raw/master/CocoaPods.alfredworkflow) the workflow directly from GitHub
 - Clone the repo (or download a zip) & double-click the `CocoaPods.alfredworkflow` file to install it into Alfred.
 - Bring Alfred up and type `pod` followed by your query.
 - Once you have a result selected Return opens the pod's homepage & Alt+Return copies the pod's definition for your `podfile`.


### PR DESCRIPTION
Instead of cloning the repo or downloading a zip it makes more sense to download the workflow so I added this option to the `How to use it` section of the README.
